### PR TITLE
Updating base image to fix compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/jdk-community:17-ol9
+FROM ghcr.io/graalvm/jdk-community:21
 
 EXPOSE 25565/tcp
 


### PR DESCRIPTION
This pull request addresses the need for compatibility with the latest versions of PurpurMC by updating the base image to Java Version 21.

Thanks for creating this repo btw ^^